### PR TITLE
Add `files` Array to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@ybot1122/react-fullpage-slideshow",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "React component to create a fullpage slideshow.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js",
   "scripts": {
     "test": "jest",
     "typecheck": "tsc --no-emit",
@@ -13,6 +14,7 @@
     "build": "rollup -c",
     "lint": "npx eslint . --fix"
   },
+  "files": ["dist"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ybot1122/react-fullpage-slideshow.git"


### PR DESCRIPTION
Add `files` array to `package.json`. This should hopefully fix npm publish.

NPM publish was not including the `dist` directory. 