### PR TITLE
FEATURE: Option for Partial SlideAnimationTiming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,58 @@
 
 React Component to create a fullpage slideshow. Works with touch devices.
 
+# Getting Started
+
+Install the package
+
+`npm i --save @ybot1122/react-fullpage-slideshow`
+
+Import and pass items in
+
+```tsx
+import { ReactFullpageSlideshow } from "../src";
+
+const slideshow = () => (
+  <ReactFullpageSlideshow
+    items={[
+      (rfsApi) => <div>slide 1</div>,
+      (rfsApi) => <div>slide 2</div>,
+      (rfsApi) => <div>slide 3</div>,
+      (rfsApi) => <div>slide 4</div>,
+      (rfsApi) => <div>slide 5</div>,
+    ]}
+  />
+);
+```
+
+# ReactFullpageSlideshow Props
+
+The ReactFullpageSlideshow component accepts props to customize and configure the look and feel of the slideshow.
+
+`itemClassName?: string;`: Passes a classname to the wrapper around each slide. Default: `''`
+
+`slideAnimationMs?: number;`: Duration for the slide animation. Default: `1000`
+
+`slideAnimationTiming?: "partial" | "full";`: When set to full (default), all slide animations will always run for the full duration set in slideAnimationMs. When set to partial, slide animations will be proportional to its distance to completion.
+
+For example: an animation that goes to the next page will take slideAnimationMs. But an animation that starts from the mid-screen will run for 0.5 \* slideAnimationMs
+
+`swipeMinThresholdMs?: number;`: The minimum duration for a gesture to be considered a swipe. Default: `50`
+
+`swipeMaxThresholdMs?: number;`: The maximum duration for a gesture to be considered a swipe. Default: `300`
+
+`swipeMinDistance?: number;`: The minimum distance required for a gesture to be considered a swipe. Default: `100`
+
+# rfsApi
+
+Each item is passed an object called `rfsApi`. This object exposes methods that the items can use to control the slideshow.
+
+`rfsApi.goToPreviousSlide()`: Causes slideshow to go to previous slide.
+
+`rfsApi.goToNextSlide()`: Causes slideshow to go to next slide.
+
+`rfsApi.goToSlide(index: number)`: Causes slideshow to go to a specific slide.
+
 # Local Development
 
 1. `npm i`

--- a/test/PartialAnimationTiming.test.tsx
+++ b/test/PartialAnimationTiming.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { App } from "./utils";
+
+jest.useFakeTimers();
+
+test("PartialAnimationTiming", async () => {
+  // @ts-expect-error overriding PointerEvent on window
+  window.PointerEvent = MouseEvent;
+
+  render(<App slideAnimationTiming="partial" />);
+  assertSlidePosition(0);
+  const main = screen.getByRole("main");
+  jest
+    .spyOn(document.documentElement, "clientHeight", "get")
+    .mockImplementation(() => 500);
+
+  await act(async () => {
+    await fireEvent.pointerDown(main, { clientY: 250, ctrlKey: false });
+    await fireEvent.pointerMove(main, { clientY: 0, ctrlKey: false });
+    jest.advanceTimersByTime(101);
+    await fireEvent.pointerUp(main, { clientY: 0, ctrlKey: false });
+  });
+
+  assertSlidePosition(1);
+
+  // clicking button should be no-op because it is still animating
+  await fireEvent.click(screen.getByText("Next-Slide-slide 2"));
+  assertSlidePosition(1);
+
+  jest.advanceTimersByTime(499);
+
+  // clicking button should be no-op because it is still animating
+  await fireEvent.click(screen.getByText("Next-Slide-slide 2"));
+  assertSlidePosition(1);
+
+  await act(async () => {
+    jest.advanceTimersByTime(1);
+  });
+
+  // clicking button work because animation is done in only 500ms
+  await fireEvent.click(screen.getByText("Next-Slide-slide 2"));
+  assertSlidePosition(2);
+});
+
+const assertSlidePosition = (activeIndex: number) => {
+  const slides = [0, 1, 2, 3, 4];
+  slides.map((ind) => {
+    const top = `calc(${(ind - activeIndex) * 100}vh + ${0}px)`;
+    expect(
+      screen.getByText(`slide ${ind + 1}`).parentNode.parentNode,
+    ).toHaveStyle(`top: ${top}`);
+  });
+};

--- a/test/SwipeTest.test.tsx
+++ b/test/SwipeTest.test.tsx
@@ -18,8 +18,10 @@ test("SwipeTest", async () => {
 
   await act(async () => {
     await fireEvent.pointerDown(main, { clientY: 101, ctrlKey: false });
+    await fireEvent.pointerMove(main, { clientY: 0, ctrlKey: false });
     await new Promise((resolve) => setTimeout(resolve, 51));
     await fireEvent.pointerUp(main, { clientY: 0, ctrlKey: false });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
   });
 
   assertSlidePosition(1);

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -2,10 +2,15 @@ import React from "react";
 import { ReactFullpageSlideshow } from "../src";
 import { rfsApi } from "../src/types";
 
-export const App = () => {
+export const App = ({
+  slideAnimationTiming = "full",
+}: {
+  slideAnimationTiming?: "full" | "partial";
+}) => {
   return (
     <main>
       <ReactFullpageSlideshow
+        slideAnimationTiming={slideAnimationTiming}
         items={[
           (api) => <Slide {...api} label="slide 1" />,
           (api) => <Slide {...api} label="slide 2" />,


### PR DESCRIPTION
- Adds a new feature that allows a user to define `SlideAnimationTiming`.
- When set to `full` (default), all slide animations will always run for the full duration set in `slideAnimationMs`
- When set to `partial`, slide animations will be proportional to its distance to completion. For example: an animation that goes to the next page will take `slideAnimationMs`. But an animation that starts from the mid-screen will run for `0.5 * slideAnimationMs` 